### PR TITLE
 Feature: stop making local folders when editing remotly

### DIFF
--- a/plugin/mkdir.vim
+++ b/plugin/mkdir.vim
@@ -7,6 +7,10 @@ let g:mkdir_loaded = 1
 function s:Mkdir()
   let dir = expand('%:p:h')
 
+  if dir =~ '://'
+    return
+  endif
+
   if !isdirectory(dir)
     call mkdir(dir, 'p')
     echo 'Created non-existing directory: '.dir


### PR DESCRIPTION
While editing remote files as follows:

```
 vim scp://user@remote-machine//home/user/coolproject.txt
```
After saving, I noticed that the following directory structure was made in my local system
```
scp:/
└── user@remote-machine
    └── home
        └── user
```

Which is unwanted behavior if you ask me.

my fix isn't perfect but it gets the job done, if you can improve on it then I'll be grateful! 